### PR TITLE
Add the command to copy busybox wasm binary to `umdist/bin`.

### DIFF
--- a/phases/build-phase4-userland.cmake
+++ b/phases/build-phase4-userland.cmake
@@ -3,6 +3,11 @@ set(busybox ${root}/busybox)
 set(prefix ${root}/prefix)
 set(toolchain ${root}/_toolchain)
 set(host ${root}/host)
+set(umdist ${root}/umdist)
+
+if(NOT EXISTS ${umdist})
+  file(MAKE_DIRECTORY ${umdist}/bin)
+endif()
  
 # Copy .config
 if(NOT EXISTS ${busybox}/.config)
@@ -39,6 +44,10 @@ execute_process(
   WORKING_DIRECTORY ${busybox}
   RESULT_VARIABLE rr
   )
+
+execute_process(
+  COMMAND ${CMAKE_COMMAND} -E copy
+  ${busybox}/busybox ${umdist}/bin/busybox)
 
 if(rr)
   message(FATAL_ERROR "Err: ${rr}")


### PR DESCRIPTION
This PR enables us to copy the built busybox wasm binary to `umdist/bin`.